### PR TITLE
Fix wrong bounds usage, switched to size deltas

### DIFF
--- a/convolution.go
+++ b/convolution.go
@@ -99,7 +99,7 @@ func Convolve(img image.Image, k ConvolutionMatrix, o *ConvolutionOptions) *imag
 	src := CloneAsRGBA(img)
 	dst := image.NewRGBA(bounds)
 
-	w, h := bounds.Max.X, bounds.Max.Y
+	w, h := bounds.Dx(), bounds.Dy()
 	kernelLengthX := k.MaxX()
 	kernelLengthY := k.MaxY()
 

--- a/effects.go
+++ b/effects.go
@@ -115,17 +115,17 @@ func Median(img image.Image, size int) *image.RGBA {
 
 	dst := image.NewRGBA(bounds)
 
-	w, h := bounds.Max.X, bounds.Max.Y
+	w, h := bounds.Dx(), bounds.Dy()
 	neighborsCount := size * size
 
 	parallelize(h, func(start, end int) {
-		for x := 0; x < w; x++ {
-			for y := start; y < end; y++ {
+		for y := start; y < end; y++ {
+			for x := 0; x < w; x++ {
 
 				neighbors := make([]color.RGBA, neighborsCount)
 				i := 0
-				for kx := 0; kx < size; kx++ {
-					for ky := 0; ky < size; ky++ {
+				for ky := 0; ky < size; ky++ {
+					for kx := 0; kx < size; kx++ {
 						ix := (x - size/2 + kx + w) % (w)
 						iy := (y - size/2 + ky + h) % h
 

--- a/helpers.go
+++ b/helpers.go
@@ -19,12 +19,26 @@ func CloneAsRGBA(src image.Image) *image.RGBA {
 func apply(img image.Image, fn func(color.RGBA) color.RGBA) *image.RGBA {
 	bounds := img.Bounds()
 	dst := CloneAsRGBA(img)
-	w, h := bounds.Max.X, bounds.Max.Y
+	w, h := bounds.Dx(), bounds.Dy()
 
 	parallelize(h, func(start, end int) {
-		for x := 0; x < w; x++ {
-			for y := start; y < end; y++ {
-				dst.Set(x, y, fn(dst.RGBAAt(x, y)))
+		for y := start; y < end; y++ {
+			for x := 0; x < w; x++ {
+				dstPos := y*dst.Stride + x*4
+
+				c := color.RGBA{}
+
+				c.R = dst.Pix[dstPos+0]
+				c.G = dst.Pix[dstPos+1]
+				c.B = dst.Pix[dstPos+2]
+				c.A = dst.Pix[dstPos+3]
+
+				c = fn(c)
+
+				dst.Pix[dstPos+0] = c.R
+				dst.Pix[dstPos+1] = c.G
+				dst.Pix[dstPos+2] = c.B
+				dst.Pix[dstPos+3] = c.A
 			}
 		}
 	})

--- a/resize.go
+++ b/resize.go
@@ -92,7 +92,7 @@ func Crop(img image.Image, rect image.Rectangle) *image.RGBA {
 }
 
 func resampleHorizontal(src *image.RGBA, width int, filter ResampleFilter) *image.RGBA {
-	srcWidth, srcHeight := src.Bounds().Max.X, src.Bounds().Max.Y
+	srcWidth, srcHeight := src.Bounds().Dx(), src.Bounds().Dy()
 	srcStride := src.Stride
 
 	delta := float64(srcWidth) / float64(width)
@@ -147,7 +147,7 @@ func resampleHorizontal(src *image.RGBA, width int, filter ResampleFilter) *imag
 }
 
 func resampleVertical(src *image.RGBA, height int, filter ResampleFilter) *image.RGBA {
-	srcWidth, srcHeight := src.Bounds().Max.X, src.Bounds().Max.Y
+	srcWidth, srcHeight := src.Bounds().Dx(), src.Bounds().Dy()
 	srcStride := src.Stride
 
 	delta := float64(srcHeight) / float64(height)
@@ -201,7 +201,7 @@ func resampleVertical(src *image.RGBA, height int, filter ResampleFilter) *image
 }
 
 func nearestNeighbor(src *image.RGBA, width, height int) *image.RGBA {
-	srcW, srcH := src.Bounds().Max.X, src.Bounds().Max.Y
+	srcW, srcH := src.Bounds().Dx(), src.Bounds().Dy()
 	srcStride := src.Stride
 
 	dst := image.NewRGBA(image.Rect(0, 0, width, height))

--- a/transform.go
+++ b/transform.go
@@ -7,7 +7,7 @@ func FlipH(img image.Image) *image.RGBA {
 	bounds := img.Bounds()
 	src := CloneAsRGBA(img)
 	dst := image.NewRGBA(bounds)
-	w, h := dst.Bounds().Max.X, dst.Bounds().Max.Y
+	w, h := dst.Bounds().Dx(), dst.Bounds().Dy()
 
 	parallelize(h, func(start, end int) {
 		for y := start; y < end; y++ {
@@ -33,7 +33,7 @@ func FlipV(img image.Image) *image.RGBA {
 	bounds := img.Bounds()
 	src := CloneAsRGBA(img)
 	dst := image.NewRGBA(bounds)
-	w, h := dst.Bounds().Max.X, dst.Bounds().Max.Y
+	w, h := dst.Bounds().Dx(), dst.Bounds().Dy()
 
 	parallelize(h, func(start, end int) {
 		for y := start; y < end; y++ {


### PR DESCRIPTION
Using image.bounds().Max.X or Y causes the Pix traversal to run out of bounds. Now using image.bounds().Dx() or Dy() for all cases.

This is because if an image rectangle has a non-zero starting point bounds (such as 1,1-3,3 for a 2x2 image), then the bounds().Max would return 3 as length for X and Y instead of 2. So the delta is what is really needed. 