### PR TITLE
Added function 'CloneAsGray'

### DIFF
--- a/clone/clone.go
+++ b/clone/clone.go
@@ -28,6 +28,14 @@ func AsRGBA(src image.Image) *image.RGBA {
 	return img
 }
 
+// AsGray returns an grayscale copy of the supplied image.
+func AsGray(src image.Image) *image.Gray {
+	bounds := src.Bounds()
+	img := image.NewGray(bounds)
+	draw.Draw(img, bounds, src, bounds.Min, draw.Src)
+	return img
+}
+
 // Pad returns an RGBA copy of the src image parameter with its edges padded
 // using the supplied PadMethod.
 // Parameter padX and padY correspond to the amount of padding to be applied

--- a/clone/clone_test.go
+++ b/clone/clone_test.go
@@ -199,6 +199,197 @@ func TestCloneAsRGBA(t *testing.T) {
 	}
 }
 
+func TestCloneAsGray(t *testing.T) {
+	cases := []struct {
+		desc     string
+		value    image.Image
+		expected *image.Gray
+	}{
+		{
+			desc: "RGBA",
+			value: &image.RGBA{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 4,
+				Pix: []uint8{
+					0x80, 0x80, 0x80, 0x80,
+					0x80, 0x80, 0x80, 0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "RGBA64",
+			value: &image.RGBA64{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 8,
+				Pix: []uint8{
+					0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+					0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "NRGBA",
+			value: &image.NRGBA{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 4,
+				Pix: []uint8{
+					0xFF, 0xFF, 0xFF, 0x80,
+					0xFF, 0xFF, 0xFF, 0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "NRGBA64",
+			value: &image.NRGBA{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 8,
+				Pix: []uint8{
+					0xFF, 0xFF, 0xFF, 0x80, 0xFF, 0xFF, 0xFF, 0x80,
+					0xFF, 0xFF, 0xFF, 0x80, 0xFF, 0xFF, 0xFF, 0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "Gray",
+			value: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "Gray16",
+			value: &image.Gray16{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 2,
+				Pix: []uint8{
+					0x80, 0x80,
+					0x80, 0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "Alpha",
+			value: &image.Alpha{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "Alpha16",
+			value: &image.Alpha16{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80, 0x80,
+					0x80, 0x80,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0x80,
+				},
+			},
+		},
+		{
+			desc: "Paletted",
+			value: &image.Paletted{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Palette: color.Palette{
+					color.RGBA{0x00, 0x00, 0x00, 0x00},
+					color.RGBA{0x80, 0x80, 0x80, 0x80},
+					color.RGBA{0xFF, 0xFF, 0xFF, 0xFF},
+				},
+				Pix: []uint8{
+					0x1, 0x2,
+				},
+			},
+			expected: &image.Gray{
+				Rect:   image.Rect(0, 0, 1, 2),
+				Stride: 1,
+				Pix: []uint8{
+					0x80,
+					0xFF,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := AsGray(c.value)
+		if !util.GrayImageEqual(actual, c.expected) {
+			t.Errorf("%s: expected: %#v, actual: %#v", "CloneAsGray from "+c.desc, c.expected, actual)
+		}
+	}
+}
+
 func TestPad(t *testing.T) {
 	cases := []struct {
 		desc     string


### PR DESCRIPTION
### Functions for grayscale manipulation
I intend to write some functions for grayscale manipulation, such as threshold using the Otsu method or multilevel threshold. I would like you to accept this initial change so that I can continue with the work.

Best Regards,

João Wiciuk