### PR TITLE
Add the option to pass a heuristic for the grayscale effect

### DIFF
--- a/effect/effect.go
+++ b/effect/effect.go
@@ -30,6 +30,11 @@ func Invert(src image.Image) *image.RGBA {
 // Grayscale returns a copy of the image in Grayscale using the weights
 // 0.3R + 0.6G + 0.1B as a heuristic.
 func Grayscale(img image.Image) *image.Gray {
+	return GrayscaleWithWeights(img, 0.3, 0.6, 0.1)
+}
+
+// GrayscaleWithWeights returns a copy of the image in Grayscale using the given weights
+func GrayscaleWithWeights(img image.Image, r, g, b float64) *image.Gray {
 	src := clone.AsRGBA(img)
 	bounds := src.Bounds()
 	srcW, srcH := bounds.Dx(), bounds.Dy()
@@ -46,7 +51,7 @@ func Grayscale(img image.Image) *image.Gray {
 				srcPos := y*src.Stride + x*4
 				dstPos := y*dst.Stride + x
 
-				c := 0.3*float64(src.Pix[srcPos+0]) + 0.6*float64(src.Pix[srcPos+1]) + 0.1*float64(src.Pix[srcPos+2])
+				c := r*float64(src.Pix[srcPos+0]) + g*float64(src.Pix[srcPos+1]) + b*float64(src.Pix[srcPos+2])
 				dst.Pix[dstPos] = uint8(c + 0.5)
 			}
 		}

--- a/effect/effect.go
+++ b/effect/effect.go
@@ -29,31 +29,34 @@ func Invert(src image.Image) *image.RGBA {
 
 // Grayscale returns a copy of the image in Grayscale using the weights
 // 0.3R + 0.6G + 0.1B as a heuristic.
-func Grayscale(img image.Image) *image.Gray {
+func Grayscale(img image.Image) *image.RGBA {
 	return GrayscaleWithWeights(img, 0.3, 0.6, 0.1)
 }
 
 // GrayscaleWithWeights returns a copy of the image in Grayscale using the given weights.
 // The weights should be in the range 0.0 to 1.0 inclusive.
-func GrayscaleWithWeights(img image.Image, r, g, b float64) *image.Gray {
+func GrayscaleWithWeights(img image.Image, r, g, b float64) *image.RGBA {
 	src := clone.AsRGBA(img)
 	bounds := src.Bounds()
 	srcW, srcH := bounds.Dx(), bounds.Dy()
 
 	if bounds.Empty() {
-		return &image.Gray{}
+		return &image.RGBA{}
 	}
 
-	dst := image.NewGray(bounds)
+	dst := image.NewRGBA(bounds)
 
 	parallel.Line(srcH, func(start, end int) {
 		for y := start; y < end; y++ {
 			for x := 0; x < srcW; x++ {
-				srcPos := y*src.Stride + x*4
-				dstPos := y*dst.Stride + x
+				pos := y*src.Stride + x*4
 
-				c := r*float64(src.Pix[srcPos+0]) + g*float64(src.Pix[srcPos+1]) + b*float64(src.Pix[srcPos+2])
-				dst.Pix[dstPos] = uint8(c + 0.5)
+				c := r*float64(src.Pix[pos+0]) + g*float64(src.Pix[pos+1]) + b*float64(src.Pix[pos+2])
+				k := uint8(c + 0.5)
+				dst.Pix[pos] = k
+				dst.Pix[pos+1] = k
+				dst.Pix[pos+2] = k
+				dst.Pix[pos+3] = src.Pix[pos+3]
 			}
 		}
 	})

--- a/effect/effect.go
+++ b/effect/effect.go
@@ -33,7 +33,8 @@ func Grayscale(img image.Image) *image.Gray {
 	return GrayscaleWithWeights(img, 0.3, 0.6, 0.1)
 }
 
-// GrayscaleWithWeights returns a copy of the image in Grayscale using the given weights
+// GrayscaleWithWeights returns a copy of the image in Grayscale using the given weights.
+// The weights should be in the range 0.0 to 1.0 inclusive.
 func GrayscaleWithWeights(img image.Image, r, g, b float64) *image.Gray {
 	src := clone.AsRGBA(img)
 	bounds := src.Bounds()

--- a/effect/effect_test.go
+++ b/effect/effect_test.go
@@ -116,7 +116,7 @@ func TestInvert(t *testing.T) {
 func TestGrayscale(t *testing.T) {
 	cases := []struct {
 		value    image.Image
-		expected *image.Gray
+		expected *image.RGBA
 	}{
 		{
 			value: &image.RGBA{
@@ -127,12 +127,12 @@ func TestGrayscale(t *testing.T) {
 					0x31, 0xFF, 0x0, 0xFF, 0x0, 0xFF, 0x0, 0xFF,
 				},
 			},
-			expected: &image.Gray{
+			expected: &image.RGBA{
 				Rect:   image.Rect(0, 0, 2, 2),
 				Stride: 2,
 				Pix: []uint8{
-					0xb9, 0x7f,
-					0xa8, 0x99,
+					0xb9, 0xb9, 0xb9, 0x80, 0x7f, 0x7f, 0x7f, 0xff,
+					0xa8, 0xa8, 0xa8, 0xff, 0x99, 0x99, 0x99, 0xff,
 				},
 			},
 		},
@@ -145,12 +145,12 @@ func TestGrayscale(t *testing.T) {
 					0x71, 0xFF, 0x0, 0xFF, 0x0, 0xFF, 0xFF, 0xFF,
 				},
 			},
-			expected: &image.Gray{
+			expected: &image.RGBA{
 				Rect:   image.Rect(0, 0, 2, 2),
 				Stride: 2,
 				Pix: []uint8{
-					0xaf, 0x7f,
-					0xbb, 0xb3,
+					0xaf, 0xaf, 0xaf, 0x80, 0x7f, 0x7f, 0x7f, 0xff,
+					0xbb, 0xbb, 0xbb, 0xff, 0xb3, 0xb3, 0xb3, 0xff,
 				},
 			},
 		},
@@ -163,12 +163,12 @@ func TestGrayscale(t *testing.T) {
 					0x88, 0x88, 0x88, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
 				},
 			},
-			expected: &image.Gray{
+			expected: &image.RGBA{
 				Rect:   image.Rect(0, 0, 2, 2),
 				Stride: 2,
 				Pix: []uint8{
-					0x00, 0x88,
-					0x88, 0xFF,
+					0x00, 0x00, 0x00, 0xFF, 0x88, 0x88, 0x88, 0xFF,
+					0x88, 0x88, 0x88, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
 				},
 			},
 		},
@@ -176,8 +176,67 @@ func TestGrayscale(t *testing.T) {
 
 	for _, c := range cases {
 		actual := Grayscale(c.value)
-		if !util.GrayImageEqual(actual, c.expected) {
+		if !util.RGBAImageEqual(actual, c.expected) {
 			t.Errorf("%s: expected: %#v, actual: %#v", "Grayscale", c.expected, actual)
+		}
+	}
+}
+
+func TestGrayscaleWithWeigths(t *testing.T) {
+	cases := []struct {
+		value    image.Image
+		expected *image.RGBA
+	}{
+		{
+			value: &image.RGBA{
+				Rect:   image.Rect(0, 0, 2, 2),
+				Stride: 8,
+				Pix: []uint8{
+					0xAA, 0x00, 0x7B, 0x80,
+					0x7f, 0x00, 0x7f, 0xFF,
+					0x31, 0x00, 0x0, 0xFF,
+					0x0, 0x00, 0x0, 0xFF,
+				},
+			},
+			expected: &image.RGBA{
+				Rect:   image.Rect(0, 0, 2, 2),
+				Stride: 2,
+				Pix: []uint8{
+					0x93, 0x93, 0x93, 0x80,
+					0x7f, 0x7f, 0x7f, 0xff,
+					0x19, 0x19, 0x19, 0xff,
+					0x0, 0x0, 0x0, 0xff,
+				},
+			},
+		},
+		{
+			value: &image.RGBA{
+				Rect:   image.Rect(0, 0, 2, 2),
+				Stride: 8,
+				Pix: []uint8{
+					0xAA, 0xCA, 0x7B, 0x80,
+					0x7f, 0x7f, 0x7f, 0xFF,
+					0x31, 0xFF, 0x0, 0xFF,
+					0x0, 0xFF, 0x0, 0xFF,
+				},
+			},
+			expected: &image.RGBA{
+				Rect:   image.Rect(0, 0, 2, 2),
+				Stride: 2,
+				Pix: []uint8{
+					0x93, 0x93, 0x93, 0x80,
+					0x7f, 0x7f, 0x7f, 0xff,
+					0x19, 0x19, 0x19, 0xff,
+					0x0, 0x0, 0x0, 0xff,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := GrayscaleWithWeights(c.value, 0.5, 0.0, 0.5)
+		if !util.RGBAImageEqual(actual, c.expected) {
+			t.Errorf("%s: expected: %#v, actual: %#v", "GrayscaleWithWeigths", c.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Adds a new function with signature:

```go
func GrayscaleWithWeights(img image.Image, r, g, b float64) *image.Gray
```

This fixes #65 