### PR TITLE
feat: improve adjust apply

### DIFF
--- a/adjust/apply.go
+++ b/adjust/apply.go
@@ -21,17 +21,22 @@ func Apply(img image.Image, fn func(color.RGBA) color.RGBA) *image.RGBA {
 
 				c := color.RGBA{}
 
-				c.R = dst.Pix[dstPos+0]
-				c.G = dst.Pix[dstPos+1]
-				c.B = dst.Pix[dstPos+2]
-				c.A = dst.Pix[dstPos+3]
+				dr := &dst.Pix[dstPos+0]
+				dg := &dst.Pix[dstPos+1]
+				db := &dst.Pix[dstPos+2]
+				da := &dst.Pix[dstPos+3]
+
+				c.R = *dr
+				c.G = *dg
+				c.B = *db
+				c.A = *da
 
 				c = fn(c)
 
-				dst.Pix[dstPos+0] = c.R
-				dst.Pix[dstPos+1] = c.G
-				dst.Pix[dstPos+2] = c.B
-				dst.Pix[dstPos+3] = c.A
+				*dr = c.R
+				*dg = c.G
+				*db = c.B
+				*da = c.A
 			}
 		}
 	})

--- a/adjust/apply_test.go
+++ b/adjust/apply_test.go
@@ -111,3 +111,21 @@ func TestClampFloat64(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkApply(b *testing.B) {
+	val := &image.RGBA{
+		Rect:   image.Rect(0, 0, 2, 2),
+		Stride: 2 * 4,
+		Pix: []uint8{
+			0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+			0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		},
+	}
+	fn := func(c color.RGBA) color.RGBA {
+		return color.RGBA{c.R - 64, c.G - 64, c.B - 64, c.A - 64}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Apply(val, fn)
+	}
+}


### PR DESCRIPTION
### Benchmark Result

```
$ go test -run=apply_test.go -benchtime=1s -bench=^BenchmarkApply -cpuprofile=cpu.out -benchmem -memprofile=mem.out -trace trace.out -count=5 > old.txt
$ go test -run=apply_test.go -benchtime=1s -bench=^BenchmarkApply -cpuprofile=cpu.out -benchmem -memprofile=mem.out -trace trace.out -count=5 > new.txt
```

`benchcmp old.txt new.txt` Result:

```
benchmark                 old ns/op     new ns/op     delta
BenchmarkApply-8          216           208           -3.70%
BenchmarkApply-8          216           208           -3.70%
BenchmarkApply-8          216           207           -4.17%
BenchmarkApply-8          215           209           -2.79%
BenchmarkApply-8          216           210           -2.78%

benchmark                 old allocs     new allocs     delta
BenchmarkApply-8          3              3              +0.00%
BenchmarkApply-8          3              3              +0.00%
BenchmarkApply-8          3              3              +0.00%
BenchmarkApply-8          3              3              +0.00%
BenchmarkApply-8          3              3              +0.00%

benchmark                 old bytes     new bytes     delta
BenchmarkApply-8          112           112           +0.00%
BenchmarkApply-8          112           112           +0.00%
BenchmarkApply-8          112           112           +0.00%
BenchmarkApply-8          112           112           +0.00%
BenchmarkApply-8          112           112           +0.00%
```